### PR TITLE
Do some changes caused by integration with real-world destination.

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,6 +2,6 @@ use Mix.Config
 
 config :data_logger,
   destinations: [
-    {DataLogger.MemoryDestination, [destination: 1]},
-    {DataLogger.MemoryDestination, [destination: 2]}
+    {DataLogger.MemoryDestination, %{destination: 1}},
+    {DataLogger.MemoryDestination, %{destination: 2}}
   ]

--- a/lib/data_logger/application.ex
+++ b/lib/data_logger/application.ex
@@ -16,7 +16,7 @@ defmodule DataLogger.Application do
     additional_children =
       :data_logger
       |> Application.get_env(:destinations, [])
-      |> Enum.any?(fn {_, options} -> Map.get(options, :send_async, false) end)
+      |> Enum.any?(fn {_, options} -> options[:send_async] end)
       |> if(
         do: [{Task.Supervisor, name: DataLogger.TaskSupervisor}, LoggingSupervisor],
         else: [LoggingSupervisor]

--- a/lib/data_logger/application.ex
+++ b/lib/data_logger/application.ex
@@ -16,7 +16,7 @@ defmodule DataLogger.Application do
     additional_children =
       :data_logger
       |> Application.get_env(:destinations, [])
-      |> Enum.any?(fn {_, options} -> Keyword.get(options, :send_async, false) end)
+      |> Enum.any?(fn {_, options} -> Map.get(options, :send_async, false) end)
       |> if(
         do: [{Task.Supervisor, name: DataLogger.TaskSupervisor}, LoggingSupervisor],
         else: [LoggingSupervisor]

--- a/lib/data_logger/destination.ex
+++ b/lib/data_logger/destination.ex
@@ -6,6 +6,9 @@ defmodule DataLogger.Destination do
   An implementation should handle errors and retries by using the optional callbacks
   `DataLogger.Destination.on_error/4` or/and `DataLogger.Destination.on_success/4`.
   These functions are called with the result of the call to the `DataLogger.Destination.send_data/4` function.
+  Also an implementation can have some custom initialization, using the optional callback `DataLogger.Destination.init/1` which
+  gets the configured options from the config and can return modified options.
+  By default it returns what is passed to it.
 
   A possible implementation should look like this:
 
@@ -37,14 +40,23 @@ defmodule DataLogger.Destination do
   """
 
   @type prefix :: atom() | String.t()
-  @type(send_result :: :ok | {:ok, result :: term()}, {:error, reason :: term()})
+  @type options :: map()
+  @type send_result ::
+          :ok
+          | {:ok, result :: term()}
+          | {:error, reason :: term()}
+          | {:ok, result :: term(), options()}
+          | {:error, reason :: term(), options()}
 
-  @callback send_data(prefix(), data :: term(), options :: keyword()) :: send_result()
+  @callback send_data(prefix(), data :: term(), options()) :: send_result()
 
-  @callback on_error(error :: term(), prefix(), data :: term(), options :: keyword()) :: :ok
-  @callback on_success(result :: term(), prefix(), data :: term(), options :: keyword()) :: :ok
+  @callback initialize(options()) :: options()
 
-  @optional_callbacks on_error: 4,
+  @callback on_error(error :: term(), prefix(), data :: term(), options()) :: :ok
+  @callback on_success(result :: term(), prefix(), data :: term(), options()) :: :ok
+
+  @optional_callbacks initialize: 1,
+                      on_error: 4,
                       on_success: 4
 
   @doc false
@@ -53,12 +65,15 @@ defmodule DataLogger.Destination do
       @behaviour DataLogger.Destination
 
       @doc false
+      def initialize(options), do: options
+
+      @doc false
       def on_error(_, _, _, _), do: :ok
 
       @doc false
       def on_success(_, _, _, _), do: :ok
 
-      defoverridable on_error: 4, on_success: 4
+      defoverridable initialize: 1, on_error: 4, on_success: 4
     end
   end
 end

--- a/lib/data_logger/logger.ex
+++ b/lib/data_logger/logger.ex
@@ -65,7 +65,7 @@ defmodule DataLogger.Logger do
        ) do
     action = fn ->
       try do
-        result = Kernel.apply(destination, :send_data, [prefix, data, options])
+        result = destination.send_data(prefix, data, options)
 
         {data, result}
       rescue
@@ -84,8 +84,7 @@ defmodule DataLogger.Logger do
          data,
          %{module: destination, options: options} = state
        ) do
-    destination
-    |> Kernel.apply(:send_data, [prefix, data, options])
+    destination.send_data(prefix, data, options)
     |> handle_send_data_result(prefix, data, state)
   end
 
@@ -101,23 +100,23 @@ defmodule DataLogger.Logger do
        ) do
     case result do
       :ok ->
-        Kernel.apply(destination, :on_success, [:ok, prefix, data, options])
+        destination.on_success(:ok, prefix, data, options)
         state
 
       {:ok, reason} ->
-        Kernel.apply(destination, :on_success, [reason, prefix, data, options])
+        destination.on_success(reason, prefix, data, options)
         state
 
       {:error, reason} ->
-        Kernel.apply(destination, :on_error, [reason, prefix, data, options])
+        destination.on_error(reason, prefix, data, options)
         state
 
       {:ok, reason, updated_options} ->
-        Kernel.apply(destination, :on_success, [reason, prefix, data, options])
+        destination.on_success(reason, prefix, data, options)
         %{state | options: updated_options}
 
       {:error, reason, updated_options} ->
-        Kernel.apply(destination, :on_error, [reason, prefix, data, options])
+        destination.on_error(reason, prefix, data, options)
         %{state | options: updated_options}
     end
   end

--- a/test/data_logger_logger_supervisor_test.exs
+++ b/test/data_logger_logger_supervisor_test.exs
@@ -26,8 +26,8 @@ defmodule DataLogger.LoggerSupervisorTest do
            }
 
     [
-      {{:green, MemoryDestination, [destination: _]}, pid1, :worker, [LoggerWorker]},
-      {{:green, MemoryDestination, [destination: _]}, pid2, :worker, [LoggerWorker]}
+      {{:green, MemoryDestination, %{destination: _}}, pid1, :worker, [LoggerWorker]},
+      {{:green, MemoryDestination, %{destination: _}}, pid2, :worker, [LoggerWorker]}
     ] = Supervisor.which_children(supervisor_pid)
 
     assert Process.alive?(pid1)

--- a/test/data_logger_logging_supervisor_test.exs
+++ b/test/data_logger_logging_supervisor_test.exs
@@ -34,8 +34,8 @@ defmodule DataLogger.LoggingSupervisorTest do
            |> Enum.member?(logger_sup_pid)
 
     [
-      {{:orange, MemoryDestination, [destination: _]}, pid1, :worker, [LoggerWorker]},
-      {{:orange, MemoryDestination, [destination: _]}, pid2, :worker, [LoggerWorker]}
+      {{:orange, MemoryDestination, %{destination: _}}, pid1, :worker, [LoggerWorker]},
+      {{:orange, MemoryDestination, %{destination: _}}, pid2, :worker, [LoggerWorker]}
     ] = Supervisor.which_children(logger_sup_pid)
 
     assert Process.alive?(pid1)

--- a/test/data_logger_test.exs
+++ b/test/data_logger_test.exs
@@ -20,8 +20,8 @@ defmodule DataLoggerTest do
         |> MemoryDestination.get_data_per_topic(2)
 
       assert Map.keys(data) == ["test_prefix"]
-      assert Map.get(data, "test_prefix") |> Enum.member?({:test_event, [destination: 1]})
-      assert Map.get(data, "test_prefix") |> Enum.member?({:test_event, [destination: 2]})
+      assert Map.get(data, "test_prefix") |> Enum.member?({:test_event, %{destination: 1}})
+      assert Map.get(data, "test_prefix") |> Enum.member?({:test_event, %{destination: 2}})
     end
 
     test "sends the passed data to all the destinations configured for multiple prefixes",
@@ -39,11 +39,11 @@ defmodule DataLoggerTest do
       assert Map.keys(data) |> Enum.member?("test_prefix1")
       assert Map.keys(data) |> Enum.member?("test_prefix2")
 
-      assert Map.get(data, "test_prefix1") |> Enum.member?({:test_event1, [destination: 1]})
-      assert Map.get(data, "test_prefix1") |> Enum.member?({:test_event1, [destination: 2]})
+      assert Map.get(data, "test_prefix1") |> Enum.member?({:test_event1, %{destination: 1}})
+      assert Map.get(data, "test_prefix1") |> Enum.member?({:test_event1, %{destination: 2}})
 
-      assert Map.get(data, "test_prefix2") |> Enum.member?({:test_event2, [destination: 1]})
-      assert Map.get(data, "test_prefix2") |> Enum.member?({:test_event2, [destination: 2]})
+      assert Map.get(data, "test_prefix2") |> Enum.member?({:test_event2, %{destination: 1}})
+      assert Map.get(data, "test_prefix2") |> Enum.member?({:test_event2, %{destination: 2}})
     end
 
     test "sending with :send_async set to true works as expected", %{
@@ -57,11 +57,11 @@ defmodule DataLoggerTest do
           |> MemoryDestination.get_data_per_topic(3)
 
         assert Map.keys(data) == ["test_prefix"]
-        assert Map.get(data, "test_prefix") |> Enum.member?({:test_event, [destination: 1]})
-        assert Map.get(data, "test_prefix") |> Enum.member?({:test_event, [destination: 2]})
+        assert Map.get(data, "test_prefix") |> Enum.member?({:test_event, %{destination: 1}})
+        assert Map.get(data, "test_prefix") |> Enum.member?({:test_event, %{destination: 2}})
 
         assert Map.get(data, "test_prefix")
-               |> Enum.member?({:test_event, [destination: 3, send_async: true]})
+               |> Enum.member?({:test_event, %{destination: 3, send_async: true}})
       end)
     end
   end

--- a/test/support/memory_destination.ex
+++ b/test/support/memory_destination.ex
@@ -36,7 +36,7 @@ defmodule DataLogger.MemoryDestination do
     :ok = Application.stop(:data_logger)
 
     try do
-      async_destination = {__MODULE__, [destination: 3, send_async: true]}
+      async_destination = {__MODULE__, %{destination: 3, send_async: true}}
       Application.put_env(:data_logger, :destinations, [async_destination | destinations])
 
       {:ok, [:data_logger]} = Application.ensure_all_started(:data_logger)


### PR DESCRIPTION
The changes include:
1. Adding a custom initialization callback which will be invoked when a logger is being initialized for the first time. It can be used to add some run-time options to the already configured ones. It comes quite handy if something that will be used by the logger/destination process is available only when the application is already running.
2. Adds the ability to change the `options` on every `send_data` (completely optional), which can be used to implement some logic depending on the logger's state for that destination - for example buferring.
3. Turns the options from a keyword list into a map as it is better to pattern match and read from a map.
4. Some refactorings to reuse code.