### PR TITLE
Fix Destination Controller process leak.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule DataLogger.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.1"
 
   def project do
     [

--- a/test/destination/controller_test.exs
+++ b/test/destination/controller_test.exs
@@ -163,4 +163,10 @@ defmodule DataLogger.Destination.ControllerTest do
       )
     end
   end
+
+  test "the destination controller times out if not used", %{green_worker: pid} do
+    Process.sleep(1000 + 100)
+
+    refute Process.alive?(pid)
+  end
 end


### PR DESCRIPTION
When we send events to SQS or SNS we use this destination controller to monitor and execute any log sent to a configured destination, i.e.:

`DataLogger.log(:my_topic, [:my, :data])`

Would spawn a destination controller for the topic: `:my_topic`. And then the destination controller gets reused on subsequent calls.

Now if we don't timeout the destination controller then we leak process memory which in turn makes any users of the data logger unresponsive.

This issue is the memory leak on the gateway at least for now. I left a gateway open without restarting and noticed lots of Destination.Controller processes getting spawned on the gateway - probably the gateway creates a topic per device when sending events from the gateway directly to SNS which causes the process issue on the gateway.