### PR TITLE
Change restart strategy to transient.

### DIFF
--- a/lib/data_logger/destination/supervisor.ex
+++ b/lib/data_logger/destination/supervisor.ex
@@ -64,7 +64,7 @@ defmodule DataLogger.Destination.Supervisor do
           start:
             {Controller, :start_link,
              [[topic: topic, name: name, destination: %{module: mod, options: options}]]},
-          restart: :permanent,
+          restart: :transient,
           shutdown: 5000,
           type: :worker
         }

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule DataLogger.MixProject do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.4.2"
 
   def project do
     [

--- a/test/destination/supervisor_test.exs
+++ b/test/destination/supervisor_test.exs
@@ -40,7 +40,7 @@ defmodule DataLogger.Destination.SupervisorTest do
     Process.sleep(1500)
 
     refute Process.alive?(pid1)
-    assert Process.alive?(pid2)
+    refute Process.alive?(pid2)
   end
 
   test "supervises only the processes with the right topic, if prefix is used" do

--- a/test/destination/supervisor_test.exs
+++ b/test/destination/supervisor_test.exs
@@ -39,7 +39,6 @@ defmodule DataLogger.Destination.SupervisorTest do
 
     Process.sleep(1500)
 
-
     refute Process.alive?(pid1)
     assert Process.alive?(pid2)
   end

--- a/test/destination/supervisor_test.exs
+++ b/test/destination/supervisor_test.exs
@@ -36,6 +36,12 @@ defmodule DataLogger.Destination.SupervisorTest do
 
     assert Process.alive?(pid1)
     assert Process.alive?(pid2)
+
+    Process.sleep(1500)
+
+
+    refute Process.alive?(pid1)
+    assert Process.alive?(pid2)
   end
 
   test "supervises only the processes with the right topic, if prefix is used" do


### PR DESCRIPTION
Currently with the permanent restart strategy the supervisor tries to restart the child even though it terminates with :normal.

This behaviour was introduced to close loggers after a period of inactivity after finishing work.