### PR TITLE
Fix silent data loss when a topic's controllers go idle

### DIFF
--- a/lib/data_logger/destination/supervisor.ex
+++ b/lib/data_logger/destination/supervisor.ex
@@ -40,6 +40,21 @@ defmodule DataLogger.Destination.Supervisor do
     Supervisor.start_link(Mod, {topic, config}, name: name)
   end
 
+  @doc false
+  # Started on demand by `DataLogger.Supervisor` (a `DynamicSupervisor`) per topic.
+  # `restart: :transient` so that when this supervisor auto-shuts-down after its
+  # (significant) idle controllers stop `:normal`, the `DynamicSupervisor` does NOT
+  # restart it. Its registry entry is then released and the next `DataLogger.log/2`
+  # for the topic recreates the whole sub-tree (and re-subscribes the controllers).
+  def child_spec(opts) do
+    %{
+      id: {__MODULE__, Keyword.get(opts, :topic)},
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor,
+      restart: :transient
+    }
+  end
+
   @impl true
   def init({topic, config}) do
     all_destinations = Keyword.get(config, :destinations, @default_destinations)
@@ -65,11 +80,18 @@ defmodule DataLogger.Destination.Supervisor do
             {Controller, :start_link,
              [[topic: topic, name: name, destination: %{module: mod, options: options}]]},
           restart: :transient,
+          # Marked significant so that when every controller for this topic stops
+          # `:normal` (after its inactivity timeout), `auto_shutdown: :all_significant`
+          # tears this supervisor down too — clearing its registry entry so the next
+          # `DataLogger.log/2` recreates and re-subscribes the controllers. Without
+          # this, an idle `:transient` controller stays dead while the supervisor
+          # lingers, and `DataLogger.log/2` dispatches to zero subscribers (silent drop).
+          significant: true,
           shutdown: 5000,
           type: :worker
         }
       end)
 
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one, auto_shutdown: :all_significant)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,13 @@
 defmodule DataLogger.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.6.0"
 
   def project do
     [
       app: :data_logger,
       version: @version,
+      elixir: "~> 1.19",
       deps: deps(),
       source_url: "https://github.com/Inflowmatix/data_logger",
       description:

--- a/test/data_logger_test.exs
+++ b/test/data_logger_test.exs
@@ -64,5 +64,33 @@ defmodule DataLoggerTest do
                |> Enum.member?({:test_event, %{destination: 3, send_async: true}})
       end)
     end
+
+    test "re-delivers to a topic after its controllers go idle and are torn down", %{
+      memory_destination: memory_destination
+    } do
+      # First delivery starts the per-topic sub-tree and subscribes the controllers.
+      :ok = DataLogger.log("readd_prefix", {memory_destination, :first_event})
+      _ = MemoryDestination.get_data_per_topic(memory_destination, 2)
+
+      # Let the topic go idle: controllers self-stop after their inactivity timeout
+      # (~1s) and, being significant children under auto_shutdown: :all_significant,
+      # the per-topic supervisor tears itself down too — clearing its registry entry.
+      Process.sleep(1_500)
+
+      refute {DataLogger.Registry, {DataLogger.Destination.Supervisor, "readd_prefix"}}
+             |> Registry.whereis_name()
+             |> is_pid(),
+             "expected the idle topic supervisor to have been torn down"
+
+      # Regression: before the fix, the lingering supervisor blocked recreation and
+      # this second log was silently dropped (dispatched to zero subscribers).
+      :ok = DataLogger.log("readd_prefix", {memory_destination, :second_event})
+
+      data = MemoryDestination.get_data_per_topic(memory_destination, 4)
+
+      assert Map.get(data, "readd_prefix") |> Enum.member?({:first_event, %{destination: 1}})
+      assert Map.get(data, "readd_prefix") |> Enum.member?({:second_event, %{destination: 1}})
+      assert Map.get(data, "readd_prefix") |> Enum.member?({:second_event, %{destination: 2}})
+    end
   end
 end

--- a/test/destination/controller_test.exs
+++ b/test/destination/controller_test.exs
@@ -117,7 +117,12 @@ defmodule DataLogger.Destination.ControllerTest do
   end
 
   test "the destination on_success/4 function is called on success and on_error/4 on error when send_async is true" do
-    {:ok, _} = Task.Supervisor.start_link(name: DataLogger.TaskSupervisor)
+    # The OTP app already starts DataLogger.TaskSupervisor when any configured
+    # destination uses send_async: true, so tolerate it being already started.
+    case Task.Supervisor.start_link(name: DataLogger.TaskSupervisor) do
+      {:ok, _} -> :ok
+      {:error, {:already_started, _}} -> :ok
+    end
 
     with_mock(RedTestDestination,
       on_success: fn

--- a/test/destination/supervisor_test.exs
+++ b/test/destination/supervisor_test.exs
@@ -19,9 +19,14 @@ defmodule DataLogger.Destination.SupervisorTest do
     %{supervisor: supervisor_pid}
   end
 
-  test "supervises as many worker processes as configured destinations", %{
+  test "supervises a worker per destination, then auto-shuts-down once they go idle", %{
     supervisor: supervisor_pid
   } do
+    # The supervisor is linked to us via start_link; trap exits so its
+    # auto-shutdown doesn't take the test process down with it.
+    Process.flag(:trap_exit, true)
+    ref = Process.monitor(supervisor_pid)
+
     assert Supervisor.count_children(supervisor_pid) == %{
              active: 2,
              specs: 2,
@@ -37,10 +42,15 @@ defmodule DataLogger.Destination.SupervisorTest do
     assert Process.alive?(pid1)
     assert Process.alive?(pid2)
 
-    Process.sleep(1500)
+    # Controllers self-stop after their inactivity timeout (~1s). Because they are
+    # significant children and the supervisor uses auto_shutdown: :all_significant,
+    # the supervisor then tears itself down too — releasing its registry entry so a
+    # subsequent DataLogger.log/2 recreates (and re-subscribes) the whole sub-tree.
+    assert_receive {:DOWN, ^ref, :process, ^supervisor_pid, _reason}, 3_000
 
     refute Process.alive?(pid1)
     refute Process.alive?(pid2)
+    refute Process.alive?(supervisor_pid)
   end
 
   test "supervises only the processes with the right topic, if prefix is used" do


### PR DESCRIPTION
A per-topic Destination.Controller stops `:normal` after its inactivity timeout (added in the "process leak" fix) and is supervised `:transient`, so it is not restarted. But the per-topic Destination.Supervisor is `:one_for_one` and kept running with no children, and `DataLogger.log/2` only checks whether that *supervisor* exists before dispatching. So once a topic went idle, every subsequent `log/2` dispatched via `Registry.dispatch(DataLogger.PubSub, topic, ...)` to zero subscribers and the data was silently dropped (returns `:ok`, no error, no restart).

Re-couple the supervisor's lifetime to its controllers: mark the controllers as `significant: true` and start the per-topic supervisor with `auto_shutdown: :all_significant`, with `restart: :transient` so the parent DynamicSupervisor does not restart it. When the idle controllers stop, the supervisor now tears itself down too, releasing its registry entry — so the next `DataLogger.log/2` for the topic recreates the sub-tree and re-subscribes the controllers. This preserves the "close idle loggers" behaviour without losing data.

- supervisor.ex: significant children + auto_shutdown + transient child_spec
- supervisor_test.exs: assert the corrected lifecycle (controllers die and the supervisor auto-shuts-down)
- data_logger_test.exs: regression test proving re-delivery after a topic goes idle and is torn down (fails on the unfixed code)
- controller_test.exs: tolerate DataLogger.TaskSupervisor already started (pre-existing test-isolation flake)
- bump to 0.6.0, require elixir ~> 1.19