### PR TITLE
CI: publish data_logger to Inflowmatix Hex org on merge to master

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,5 +1,8 @@
 name: Test Data Logger and publish
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   build:
@@ -30,3 +33,20 @@ jobs:
         MIX_ENV=test mix format --check-formatted
         MIX_ENV=test mix test
       working-directory: /home/runner/work/data_logger/data_logger
+    - name: Publish to Hex (Inflowmatix org)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: |
+        set +e
+        output=$(mix hex.publish package --yes 2>&1)
+        status=$?
+        echo "$output"
+        if [ $status -ne 0 ]; then
+          if echo "$output" | grep -qiE "has already been published|already released"; then
+            echo "::notice::Version already published to Hex, skipping."
+            exit 0
+          fi
+          exit $status
+        fi
+      working-directory: /home/runner/work/data_logger/data_logger
+      env:
+        HEX_API_KEY: ${{ secrets.HEX_KEY }}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule DataLogger.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
 
   def project do
     [
@@ -38,6 +38,7 @@ defmodule DataLogger.MixProject do
   defp package do
     [
       name: "data_logger",
+      organization: "inflowmatix",
       maintainers: ["Inflowmatix"],
       licenses: ["MIT License"],
       links: %{"GitHub" => "https://github.com/Inflowmatix/data_logger"},


### PR DESCRIPTION
- Add organization: "inflowmatix" to mix.exs package so hex.publish targets the private org repo instead of public hex.pm.
- Trigger the workflow on push to master (every merge) in addition to pull_request, and add a guarded 'mix hex.publish package' step that no-ops when the version is already published.
- Bump version to 0.6.1.